### PR TITLE
Fix: menu re-creation was not changing mMenu in MenuView

### DIFF
--- a/v7/appcompat/src/android/support/v7/internal/view/menu/BaseMenuPresenter.java
+++ b/v7/appcompat/src/android/support/v7/internal/view/menu/BaseMenuPresenter.java
@@ -65,6 +65,10 @@ public abstract class BaseMenuPresenter implements MenuPresenter {
         mContext = context;
         mInflater = LayoutInflater.from(mContext);
         mMenu = menu;
+        if (mMenuView != null) {
+            mMenuView.initialize(mMenu);
+            updateMenuView(true);
+        }
     }
 
     public MenuView getMenuView(ViewGroup root) {


### PR DESCRIPTION
## UPD: Sorry, it turns out that this bug was already reported…

Hi!

Found a bug not allowing me to use submenus in Fragment's options menu.

While adding a fragment having options menu via FragmentTransaction, MenuBuilder were correctly re-created but new instance of MenuBuilder were not passed to MenuView.
This caused Fragment's MenuItems reference an old MenuBuilder. This, in turn, caused submenu fail to show because no MenuPresenters were available to that old MenuBuilder.

NOTE: I'm not sure calling the 'initialize' method here is the best way to go. That might be better to modify MenuView interface to support something like 'setMenu'.
