### PR TITLE
Remove animation offsetting touch coordinates

### DIFF
--- a/recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/ItemTouchHelper.java
+++ b/recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/ItemTouchHelper.java
@@ -327,8 +327,6 @@ public class ItemTouchHelper extends RecyclerView.ItemDecoration
                 if (mSelected == null) {
                     final RecoverAnimation animation = findAnimation(event);
                     if (animation != null) {
-                        mInitialTouchX -= animation.mX;
-                        mInitialTouchY -= animation.mY;
                         endRecoverAnimation(animation.mViewHolder, true);
                         if (mPendingCleanup.remove(animation.mViewHolder.itemView)) {
                             mCallback.clearView(mRecyclerView, animation.mViewHolder);


### PR DESCRIPTION
These lines attempt to move the touch coordinates into the target view's coordinate space, but everywhere else in the file uses the RecyclerView's coordinate space, causing erroneous calculations when this is in effect.